### PR TITLE
fix: os_timer_create missing one_shot

### DIFF
--- a/firmware/concurrent_hal.cpp
+++ b/firmware/concurrent_hal.cpp
@@ -409,7 +409,7 @@ int os_semaphore_give(os_semaphore_t semaphore, bool reserved)
 /**
  * Create a new timer. Returns 0 on success.
  */
-int os_timer_create(os_timer_t* timer, unsigned period, void (*callback)(os_timer_t timer), void* const timer_id, void* reserved)
+int os_timer_create(os_timer_t* timer, unsigned period, void (*callback)(os_timer_t timer), void* const timer_id, bool one_shot, void* reserved)
 {
     *timer = xTimerCreate((_CREATE_NAME_TYPE*)"", period, true, timer_id, callback);
     return *timer==NULL;


### PR DESCRIPTION
Related issue: https://github.com/spark/firmware/issues/924
