### PR TITLE
Fix for software timers cause hard fault issue

### DIFF
--- a/firmware/freertos4core.cpp
+++ b/firmware/freertos4core.cpp
@@ -41,7 +41,7 @@ void rtos_start(TaskHandle_t handle)
 }
 
 static TaskHandle_t  app_thread_handle;
-#define APPLICATION_STACK_SIZE 1024*2
+#define APPLICATION_STACK_SIZE 1024*3
 
 
 extern "C" void HAL_Hook_Main()


### PR DESCRIPTION
Fix for #2.

In the discussion of spark/firmware#990 it was mentioned that merely including this library on Build will cause a hard fault.

Issue was caused by a stack overflow. Raised the stack size to 3 KB.

For experimental sake, I tried 4 KB and this resulted in OutOfHeap
errors—so there’s not much more RAM left. I was at least able to do a simple
Particle.publish() in the user app loop without issues.
